### PR TITLE
fix: add role attribute to button and link

### DIFF
--- a/packages/evergarden/src/Button/index.js
+++ b/packages/evergarden/src/Button/index.js
@@ -8,6 +8,14 @@ export const Button = {
   inheritAttrs: false,
 
   props: {
+    as: {
+      type: String,
+      default: 'button'
+    },
+    type: {
+      type: String,
+      default: 'button'
+    },
     variant: {
       type: String,
       default: 'solid'
@@ -33,10 +41,19 @@ export const Button = {
         size: this.size,
         ...this.$evergarden
       }),
+      as: this.as,
       disabled: this.isDisabled,
       'aria-disabled': this.isDisabled
     }
+
+    if (this.as === 'button') {
+      childAttrs.type = this.type
+    } else {
+      childAttrs.role = 'button'
+    }
+
     mergeAttrs(childAttrs, this.$attrs)
+
     return h(
       Box,
       {

--- a/packages/evergarden/src/Link/index.js
+++ b/packages/evergarden/src/Link/index.js
@@ -50,6 +50,10 @@ export const Link = {
       as: this.as
     }
 
+    if (this.as !== 'a') {
+      childAttrs.role = 'link'
+    }
+
     mergeAttrs(childAttrs, this.$attrs)
 
     return h(


### PR DESCRIPTION
According to WAI-ARIA documents, these elements must contain the `role` attribute ([Link](https://www.w3.org/TR/wai-aria-practices/#link), [Button](https://www.w3.org/TR/wai-aria-practices/#button)).